### PR TITLE
Lib dirs

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -65,11 +65,15 @@ pkgname = lib32-amdgpu-pro-libopencl-dev
 	pkgdesc = AMD OpenCL ICD Loader library
 	arch = x86_64
 	depends = lib32-amdgpu-pro-libopencl1=16.30.3.306809-4
+	provides = lib32-libcl
+	conflicts = lib32-libcl
 
 pkgname = amdgpu-pro-libopencl-dev
 	pkgdesc = AMD OpenCL ICD Loader library
 	arch = x86_64
 	depends = amdgpu-pro-libopencl1=16.30.3.306809-4
+	provides = libcl
+	conflicts = libcl
 
 pkgname = lib32-amdgpu-pro-libopencl1
 	pkgdesc = AMD OpenCL ICD Loader library

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = amdgpu-pro-installer
 	pkgver = 16.30.3.306809
-	pkgrel = 4
+	pkgrel = 5
 	url = http://www.amd.com
 	arch = x86_64
 	license = custom:AMD
@@ -11,67 +11,67 @@ pkgbase = amdgpu-pro-installer
 pkgname = amdgpu-pro
 	pkgdesc = This package install all amdgpu-pro components.
 	arch = x86_64
-	depends = amdgpu-pro-graphics=16.30.3.306809-4
-	depends = amdgpu-pro-computing=16.30.3.306809-4
+	depends = amdgpu-pro-graphics=16.30.3.306809-5
+	depends = amdgpu-pro-computing=16.30.3.306809-5
 
 pkgname = amdgpu-pro-clinfo
 	pkgdesc = AMD OpenCL info utility
 	arch = x86_64
-	depends = amdgpu-pro-libopencl1=16.30.3.306809-4
+	depends = amdgpu-pro-libopencl1=16.30.3.306809-5
 
 pkgname = amdgpu-pro-computing
 	pkgdesc = This package install amdgpu-pro OpenCL components.
 	arch = x86_64
-	depends = amdgpu-pro-core=16.30.3.306809-4
-	depends = amdgpu-pro-clinfo=16.30.3.306809-4
-	depends = amdgpu-pro-opencl-icd=16.30.3.306809-4
-	depends = amdgpu-pro-libopencl-dev=16.30.3.306809-4
+	depends = amdgpu-pro-core=16.30.3.306809-5
+	depends = amdgpu-pro-clinfo=16.30.3.306809-5
+	depends = amdgpu-pro-opencl-icd=16.30.3.306809-5
+	depends = amdgpu-pro-libopencl-dev=16.30.3.306809-5
 
 pkgname = amdgpu-pro-core
 	pkgdesc = This package switchs the GPU stack to amdgpu-pro with basic components.
 	install = amdgpu-pro-core.install
 	arch = x86_64
 	depends = linux-firmware
-	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4
+	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5
 
 pkgname = amdgpu-pro-graphics
 	pkgdesc = This package install amdgpu-pro graphics components.
 	arch = x86_64
-	depends = amdgpu-pro-core=16.30.3.306809-4
-	depends = libgles2-amdgpu-pro=16.30.3.306809-4
-	depends = libgl1-amdgpu-pro-dev=16.30.3.306809-4
-	depends = libgl1-amdgpu-pro-dri=16.30.3.306809-4
-	depends = xserver-xorg-video-amdgpu-pro=16.30.3.306809-4
-	depends = amdgpu-pro-vulkan-driver=16.30.3.306809-4
-	depends = libvdpau-amdgpu-pro=16.30.3.306809-4
+	depends = amdgpu-pro-core=16.30.3.306809-5
+	depends = libgles2-amdgpu-pro=16.30.3.306809-5
+	depends = libgl1-amdgpu-pro-dev=16.30.3.306809-5
+	depends = libgl1-amdgpu-pro-dri=16.30.3.306809-5
+	depends = xserver-xorg-video-amdgpu-pro=16.30.3.306809-5
+	depends = amdgpu-pro-vulkan-driver=16.30.3.306809-5
+	depends = libvdpau-amdgpu-pro=16.30.3.306809-5
 	provides = libgl
 	conflicts = libgl
 
 pkgname = lib32-amdgpu-pro-lib32
 	pkgdesc = This package contains x86 libs for x86_64 machine usage.
 	arch = x86_64
-	depends = lib32-libgles2-amdgpu-pro=16.30.3.306809-4
-	depends = lib32-libgl1-amdgpu-pro-dev=16.30.3.306809-4
-	depends = lib32-libgl1-amdgpu-pro-dri=16.30.3.306809-4
-	depends = lib32-libgbm1-amdgpu-pro=16.30.3.306809-4
-	depends = lib32-amdgpu-pro-opencl-icd=16.30.3.306809-4
-	depends = lib32-amdgpu-pro-libopencl-dev=16.30.3.306809-4
-	depends = lib32-amdgpu-pro-vulkan-driver=16.30.3.306809-4
-	depends = lib32-libvdpau-amdgpu-pro=16.30.3.306809-4
+	depends = lib32-libgles2-amdgpu-pro=16.30.3.306809-5
+	depends = lib32-libgl1-amdgpu-pro-dev=16.30.3.306809-5
+	depends = lib32-libgl1-amdgpu-pro-dri=16.30.3.306809-5
+	depends = lib32-libgbm1-amdgpu-pro=16.30.3.306809-5
+	depends = lib32-amdgpu-pro-opencl-icd=16.30.3.306809-5
+	depends = lib32-amdgpu-pro-libopencl-dev=16.30.3.306809-5
+	depends = lib32-amdgpu-pro-vulkan-driver=16.30.3.306809-5
+	depends = lib32-libvdpau-amdgpu-pro=16.30.3.306809-5
 	provides = lib32-libgl
 	conflicts = lib32-libgl
 
 pkgname = lib32-amdgpu-pro-libopencl-dev
 	pkgdesc = AMD OpenCL ICD Loader library
 	arch = x86_64
-	depends = lib32-amdgpu-pro-libopencl1=16.30.3.306809-4
+	depends = lib32-amdgpu-pro-libopencl1=16.30.3.306809-5
 	provides = lib32-libcl
 	conflicts = lib32-libcl
 
 pkgname = amdgpu-pro-libopencl-dev
 	pkgdesc = AMD OpenCL ICD Loader library
 	arch = x86_64
-	depends = amdgpu-pro-libopencl1=16.30.3.306809-4
+	depends = amdgpu-pro-libopencl1=16.30.3.306809-5
 	provides = libcl
 	conflicts = libcl
 
@@ -98,40 +98,40 @@ pkgname = amdgpu-pro-opencl-icd
 pkgname = amdgpu-pro-vulkan-driver
 	pkgdesc = AMDGPU Pro Vulkan driver
 	arch = x86_64
-	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4
+	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5
 
 pkgname = lib32-amdgpu-pro-vulkan-driver
 	pkgdesc = AMDGPU Pro Vulkan driver
 	arch = x86_64
-	depends = lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4
+	depends = lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5
 
 pkgname = libdrm-amdgpu-pro-amdgpu1
 	pkgdesc = Userspace interface to amdgpu-specific kernel DRM services -- runtime
 	arch = x86_64
-	depends = libdrm2-amdgpu-pro=16.30.3.306809-4
+	depends = libdrm2-amdgpu-pro=16.30.3.306809-5
 
 pkgname = lib32-libdrm-amdgpu-pro-amdgpu1
 	pkgdesc = Userspace interface to amdgpu-specific kernel DRM services -- runtime
 	arch = x86_64
-	depends = lib32-libdrm2-amdgpu-pro=16.30.3.306809-4
+	depends = lib32-libdrm2-amdgpu-pro=16.30.3.306809-5
 
 pkgname = libdrm-amdgpu-pro-dev
 	pkgdesc = Userspace interface to kernel DRM services -- development files
 	arch = x86_64
-	depends = libdrm2-amdgpu-pro=16.30.3.306809-4
-	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4
+	depends = libdrm2-amdgpu-pro=16.30.3.306809-5
+	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5
 
 pkgname = lib32-libdrm-amdgpu-pro-dev
 	pkgdesc = Userspace interface to kernel DRM services -- development files
 	arch = x86_64
-	depends = lib32-libdrm2-amdgpu-pro=16.30.3.306809-4
-	depends = lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4
+	depends = lib32-libdrm2-amdgpu-pro=16.30.3.306809-5
+	depends = lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5
 
 pkgname = libdrm-amdgpu-pro-tools
 	pkgdesc = testing tools for libdrm-amdgpu-pro
 	arch = x86_64
-	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4
-	depends = libdrm2-amdgpu-pro=16.30.3.306809-4
+	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5
+	depends = libdrm2-amdgpu-pro=16.30.3.306809-5
 
 pkgname = libdrm2-amdgpu-pro
 	pkgdesc = Userspace interface to kernel DRM services -- runtime
@@ -156,44 +156,44 @@ pkgname = lib32-libegl1-amdgpu-pro
 pkgname = libegl1-amdgpu-pro-dev
 	pkgdesc = implementation of the EGL API -- development files
 	arch = x86_64
-	depends = libegl1-amdgpu-pro=16.30.3.306809-4
+	depends = libegl1-amdgpu-pro=16.30.3.306809-5
 
 pkgname = lib32-libegl1-amdgpu-pro-dev
 	pkgdesc = implementation of the EGL API -- development files
 	arch = x86_64
-	depends = lib32-libegl1-amdgpu-pro=16.30.3.306809-4
+	depends = lib32-libegl1-amdgpu-pro=16.30.3.306809-5
 
 pkgname = lib32-libgbm-amdgpu-pro-dev
 	pkgdesc = generic buffer management API -- development files
 	arch = x86_64
-	depends = lib32-libgbm1-amdgpu-pro=16.30.3.306809-4
+	depends = lib32-libgbm1-amdgpu-pro=16.30.3.306809-5
 
 pkgname = libgbm-amdgpu-pro-dev
 	pkgdesc = generic buffer management API -- development files
 	arch = x86_64
-	depends = libgbm1-amdgpu-pro=16.30.3.306809-4
+	depends = libgbm1-amdgpu-pro=16.30.3.306809-5
 
 pkgname = libgbm1-amdgpu-pro
 	pkgdesc = generic buffer management API -- runtime
 	arch = x86_64
-	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4
-	depends = libdrm2-amdgpu-pro=16.30.3.306809-4
+	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5
+	depends = libdrm2-amdgpu-pro=16.30.3.306809-5
 
 pkgname = lib32-libgbm1-amdgpu-pro
 	pkgdesc = generic buffer management API -- runtime
 	arch = x86_64
-	depends = lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4
-	depends = lib32-libdrm2-amdgpu-pro=16.30.3.306809-4
+	depends = lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5
+	depends = lib32-libdrm2-amdgpu-pro=16.30.3.306809-5
 
 pkgname = lib32-libgl1-amdgpu-pro-dev
 	pkgdesc = implementation of the OpenGL API -- GLX development files
 	arch = x86_64
-	depends = lib32-libgl1-amdgpu-pro-glx=16.30.3.306809-4
+	depends = lib32-libgl1-amdgpu-pro-glx=16.30.3.306809-5
 
 pkgname = libgl1-amdgpu-pro-dev
 	pkgdesc = implementation of the OpenGL API -- GLX development files
 	arch = x86_64
-	depends = libgl1-amdgpu-pro-glx=16.30.3.306809-4
+	depends = libgl1-amdgpu-pro-glx=16.30.3.306809-5
 
 pkgname = lib32-libgl1-amdgpu-pro-dri
 	pkgdesc = implementation of the OpenGL API -- DRI modules
@@ -210,7 +210,7 @@ pkgname = libgl1-amdgpu-pro-dri
 pkgname = lib32-libgl1-amdgpu-pro-glx
 	pkgdesc = implementation of the OpenGL API -- GLX runtime
 	arch = x86_64
-	depends = lib32-libdrm2-amdgpu-pro=16.30.3.306809-4
+	depends = lib32-libdrm2-amdgpu-pro=16.30.3.306809-5
 	depends = lib32-libx11>=1.4.99.1
 	depends = lib32-libxcb>=1.8
 	depends = lib32-libxcb
@@ -224,7 +224,7 @@ pkgname = lib32-libgl1-amdgpu-pro-glx
 pkgname = libgl1-amdgpu-pro-glx
 	pkgdesc = implementation of the OpenGL API -- GLX runtime
 	arch = x86_64
-	depends = libdrm2-amdgpu-pro=16.30.3.306809-4
+	depends = libdrm2-amdgpu-pro=16.30.3.306809-5
 	depends = libx11>=1.4.99.1
 	depends = libxcb>=1.8
 	depends = libxcb
@@ -238,29 +238,29 @@ pkgname = libgl1-amdgpu-pro-glx
 pkgname = libgles2-amdgpu-pro
 	pkgdesc = implementation of the OpenGL|ES 2.x API -- runtime
 	arch = x86_64
-	depends = libegl1-amdgpu-pro=16.30.3.306809-4
+	depends = libegl1-amdgpu-pro=16.30.3.306809-5
 
 pkgname = lib32-libgles2-amdgpu-pro
 	pkgdesc = implementation of the OpenGL|ES 2.x API -- runtime
 	arch = x86_64
-	depends = lib32-libegl1-amdgpu-pro=16.30.3.306809-4
+	depends = lib32-libegl1-amdgpu-pro=16.30.3.306809-5
 
 pkgname = lib32-libgles2-amdgpu-pro-dev
 	pkgdesc = implementation of the OpenGL|ES 2.x API -- development files
 	arch = x86_64
-	depends = lib32-libgles2-amdgpu-pro=16.30.3.306809-4
+	depends = lib32-libgles2-amdgpu-pro=16.30.3.306809-5
 
 pkgname = libgles2-amdgpu-pro-dev
 	pkgdesc = implementation of the OpenGL|ES 2.x API -- development files
 	arch = x86_64
-	depends = libgles2-amdgpu-pro=16.30.3.306809-4
+	depends = libgles2-amdgpu-pro=16.30.3.306809-5
 
 pkgname = libvdpau-amdgpu-pro
 	pkgdesc = AMDGPU Pro VDPAU driver
 	arch = x86_64
-	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4
+	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5
 	depends = libdrm>=2.4.31
-	depends = libdrm2-amdgpu-pro=16.30.3.306809-4
+	depends = libdrm2-amdgpu-pro=16.30.3.306809-5
 	depends = openssl>=1.0.0
 	depends = libx11
 	depends = libxcb>=1.8
@@ -269,9 +269,9 @@ pkgname = libvdpau-amdgpu-pro
 pkgname = lib32-libvdpau-amdgpu-pro
 	pkgdesc = AMDGPU Pro VDPAU driver
 	arch = x86_64
-	depends = lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4
+	depends = lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5
 	depends = lib32-libdrm>=2.4.31
-	depends = lib32-libdrm2-amdgpu-pro=16.30.3.306809-4
+	depends = lib32-libdrm2-amdgpu-pro=16.30.3.306809-5
 	depends = lib32-openssl>=1.0.0
 	depends = lib32-libx11
 	depends = lib32-libxcb>=1.8
@@ -281,11 +281,11 @@ pkgname = lib32-libvdpau-amdgpu-pro
 pkgname = xserver-xorg-video-amdgpu-pro
 	pkgdesc = X.Org X server -- AMD/ATI Amdgpu-Pro display driver
 	arch = x86_64
-	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4
-	depends = libdrm2-amdgpu-pro=16.30.3.306809-4
+	depends = libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5
+	depends = libdrm2-amdgpu-pro=16.30.3.306809-5
 	depends = libepoxy>=1.0
-	depends = libgbm1-amdgpu-pro=16.30.3.306809-4
-	depends = libgl1-amdgpu-pro-glx=16.30.3.306809-4
+	depends = libgbm1-amdgpu-pro=16.30.3.306809-5
+	depends = libgl1-amdgpu-pro-glx=16.30.3.306809-5
 	depends = libsystemd>=183
 	depends = libx11
 	depends = libxcb

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,7 +8,7 @@ if [ "$ALL_PACKAGES" = "true" ]; then
 	pkgname+=(amdgpu-pro-dkms amdgpu-pro-firmware)
 fi
 pkgver=16.30.3.306809
-pkgrel=4
+pkgrel=5
 arch=('x86_64')
 url='http://www.amd.com'
 license=('custom:AMD')
@@ -22,7 +22,7 @@ sha256sums=('40fc78dc10823096882bd5840a0c49221bbd977e1eda1a9b79b620d06298c389')
 
 package_amdgpu-pro () {
 	pkgdesc="This package install all amdgpu-pro components."
-	depends=('amdgpu-pro-graphics=16.30.3.306809-4' 'amdgpu-pro-computing=16.30.3.306809-4')
+	depends=('amdgpu-pro-graphics=16.30.3.306809-5' 'amdgpu-pro-computing=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/amdgpu-pro_16.30.3-306809_amd64
@@ -41,7 +41,7 @@ package_amdgpu-pro () {
 
 package_amdgpu-pro-clinfo () {
 	pkgdesc="AMD OpenCL info utility"
-	depends=('amdgpu-pro-libopencl1=16.30.3.306809-4')
+	depends=('amdgpu-pro-libopencl1=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/amdgpu-pro-clinfo_16.30.3-306809_amd64
@@ -60,7 +60,7 @@ package_amdgpu-pro-clinfo () {
 
 package_amdgpu-pro-computing () {
 	pkgdesc="This package install amdgpu-pro OpenCL components."
-	depends=('amdgpu-pro-core=16.30.3.306809-4' 'amdgpu-pro-clinfo=16.30.3.306809-4' 'amdgpu-pro-opencl-icd=16.30.3.306809-4' 'amdgpu-pro-libopencl-dev=16.30.3.306809-4')
+	depends=('amdgpu-pro-core=16.30.3.306809-5' 'amdgpu-pro-clinfo=16.30.3.306809-5' 'amdgpu-pro-opencl-icd=16.30.3.306809-5' 'amdgpu-pro-libopencl-dev=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/amdgpu-pro-computing_16.30.3-306809_amd64
@@ -79,7 +79,7 @@ package_amdgpu-pro-computing () {
 
 package_amdgpu-pro-core () {
 	pkgdesc="This package switchs the GPU stack to amdgpu-pro with basic components."
-	depends=('linux-firmware' 'libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4')
+	depends=('linux-firmware' 'libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/amdgpu-pro-core_16.30.3-306809_amd64
@@ -149,7 +149,7 @@ package_amdgpu-pro-firmware () {
 
 package_amdgpu-pro-graphics () {
 	pkgdesc="This package install amdgpu-pro graphics components."
-	depends=('amdgpu-pro-core=16.30.3.306809-4' 'libgles2-amdgpu-pro=16.30.3.306809-4' 'libgl1-amdgpu-pro-dev=16.30.3.306809-4' 'libgl1-amdgpu-pro-dri=16.30.3.306809-4' 'xserver-xorg-video-amdgpu-pro=16.30.3.306809-4' 'amdgpu-pro-vulkan-driver=16.30.3.306809-4' 'libvdpau-amdgpu-pro=16.30.3.306809-4')
+	depends=('amdgpu-pro-core=16.30.3.306809-5' 'libgles2-amdgpu-pro=16.30.3.306809-5' 'libgl1-amdgpu-pro-dev=16.30.3.306809-5' 'libgl1-amdgpu-pro-dri=16.30.3.306809-5' 'xserver-xorg-video-amdgpu-pro=16.30.3.306809-5' 'amdgpu-pro-vulkan-driver=16.30.3.306809-5' 'libvdpau-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/amdgpu-pro-graphics_16.30.3-306809_amd64
@@ -172,7 +172,7 @@ package_amdgpu-pro-graphics () {
 
 package_lib32-amdgpu-pro-lib32 () {
 	pkgdesc="This package contains x86 libs for x86_64 machine usage."
-	depends=('lib32-libgles2-amdgpu-pro=16.30.3.306809-4' 'lib32-libgl1-amdgpu-pro-dev=16.30.3.306809-4' 'lib32-libgl1-amdgpu-pro-dri=16.30.3.306809-4' 'lib32-libgbm1-amdgpu-pro=16.30.3.306809-4' 'lib32-amdgpu-pro-opencl-icd=16.30.3.306809-4' 'lib32-amdgpu-pro-libopencl-dev=16.30.3.306809-4' 'lib32-amdgpu-pro-vulkan-driver=16.30.3.306809-4' 'lib32-libvdpau-amdgpu-pro=16.30.3.306809-4')
+	depends=('lib32-libgles2-amdgpu-pro=16.30.3.306809-5' 'lib32-libgl1-amdgpu-pro-dev=16.30.3.306809-5' 'lib32-libgl1-amdgpu-pro-dri=16.30.3.306809-5' 'lib32-libgbm1-amdgpu-pro=16.30.3.306809-5' 'lib32-amdgpu-pro-opencl-icd=16.30.3.306809-5' 'lib32-amdgpu-pro-libopencl-dev=16.30.3.306809-5' 'lib32-amdgpu-pro-vulkan-driver=16.30.3.306809-5' 'lib32-libvdpau-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/amdgpu-pro-lib32_16.30.3-306809_i386
@@ -196,7 +196,7 @@ package_lib32-amdgpu-pro-lib32 () {
 
 package_lib32-amdgpu-pro-libopencl-dev () {
 	pkgdesc="AMD OpenCL ICD Loader library"
-	depends=('lib32-amdgpu-pro-libopencl1=16.30.3.306809-4')
+	depends=('lib32-amdgpu-pro-libopencl1=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/amdgpu-pro-libopencl-dev_16.30.3-306809_i386
@@ -220,7 +220,7 @@ package_lib32-amdgpu-pro-libopencl-dev () {
 
 package_amdgpu-pro-libopencl-dev () {
 	pkgdesc="AMD OpenCL ICD Loader library"
-	depends=('amdgpu-pro-libopencl1=16.30.3.306809-4')
+	depends=('amdgpu-pro-libopencl1=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/amdgpu-pro-libopencl-dev_16.30.3-306809_amd64
@@ -321,7 +321,7 @@ package_amdgpu-pro-opencl-icd () {
 
 package_amdgpu-pro-vulkan-driver () {
 	pkgdesc="AMDGPU Pro Vulkan driver"
-	depends=('libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4')
+	depends=('libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/amdgpu-pro-vulkan-driver_16.30.3-306809_amd64
@@ -343,7 +343,7 @@ package_amdgpu-pro-vulkan-driver () {
 
 package_lib32-amdgpu-pro-vulkan-driver () {
 	pkgdesc="AMDGPU Pro Vulkan driver"
-	depends=('lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4')
+	depends=('lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/amdgpu-pro-vulkan-driver_16.30.3-306809_i386
@@ -366,7 +366,7 @@ package_lib32-amdgpu-pro-vulkan-driver () {
 
 package_libdrm-amdgpu-pro-amdgpu1 () {
 	pkgdesc="Userspace interface to amdgpu-specific kernel DRM services -- runtime"
-	depends=('libdrm2-amdgpu-pro=16.30.3.306809-4')
+	depends=('libdrm2-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libdrm-amdgpu-pro-amdgpu1_16.30.3-306809_amd64
@@ -385,7 +385,7 @@ package_libdrm-amdgpu-pro-amdgpu1 () {
 
 package_lib32-libdrm-amdgpu-pro-amdgpu1 () {
 	pkgdesc="Userspace interface to amdgpu-specific kernel DRM services -- runtime"
-	depends=('lib32-libdrm2-amdgpu-pro=16.30.3.306809-4')
+	depends=('lib32-libdrm2-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libdrm-amdgpu-pro-amdgpu1_16.30.3-306809_i386
@@ -405,7 +405,7 @@ package_lib32-libdrm-amdgpu-pro-amdgpu1 () {
 
 package_libdrm-amdgpu-pro-dev () {
 	pkgdesc="Userspace interface to kernel DRM services -- development files"
-	depends=('libdrm2-amdgpu-pro=16.30.3.306809-4' 'libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4')
+	depends=('libdrm2-amdgpu-pro=16.30.3.306809-5' 'libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libdrm-amdgpu-pro-dev_16.30.3-306809_amd64
@@ -424,7 +424,7 @@ package_libdrm-amdgpu-pro-dev () {
 
 package_lib32-libdrm-amdgpu-pro-dev () {
 	pkgdesc="Userspace interface to kernel DRM services -- development files"
-	depends=('lib32-libdrm2-amdgpu-pro=16.30.3.306809-4' 'lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4')
+	depends=('lib32-libdrm2-amdgpu-pro=16.30.3.306809-5' 'lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libdrm-amdgpu-pro-dev_16.30.3-306809_i386
@@ -444,7 +444,7 @@ package_lib32-libdrm-amdgpu-pro-dev () {
 
 package_libdrm-amdgpu-pro-tools () {
 	pkgdesc="testing tools for libdrm-amdgpu-pro"
-	depends=('libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4' 'libdrm2-amdgpu-pro=16.30.3.306809-4')
+	depends=('libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5' 'libdrm2-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libdrm-amdgpu-pro-tools_16.30.3-306809_amd64
@@ -549,7 +549,7 @@ package_lib32-libegl1-amdgpu-pro () {
 
 package_libegl1-amdgpu-pro-dev () {
 	pkgdesc="implementation of the EGL API -- development files"
-	depends=('libegl1-amdgpu-pro=16.30.3.306809-4')
+	depends=('libegl1-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libegl1-amdgpu-pro-dev_16.30.3-306809_amd64
@@ -572,7 +572,7 @@ package_libegl1-amdgpu-pro-dev () {
 
 package_lib32-libegl1-amdgpu-pro-dev () {
 	pkgdesc="implementation of the EGL API -- development files"
-	depends=('lib32-libegl1-amdgpu-pro=16.30.3.306809-4')
+	depends=('lib32-libegl1-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libegl1-amdgpu-pro-dev_16.30.3-306809_i386
@@ -596,7 +596,7 @@ package_lib32-libegl1-amdgpu-pro-dev () {
 
 package_lib32-libgbm-amdgpu-pro-dev () {
 	pkgdesc="generic buffer management API -- development files"
-	depends=('lib32-libgbm1-amdgpu-pro=16.30.3.306809-4')
+	depends=('lib32-libgbm1-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libgbm-amdgpu-pro-dev_16.30.3-306809_i386
@@ -616,7 +616,7 @@ package_lib32-libgbm-amdgpu-pro-dev () {
 
 package_libgbm-amdgpu-pro-dev () {
 	pkgdesc="generic buffer management API -- development files"
-	depends=('libgbm1-amdgpu-pro=16.30.3.306809-4')
+	depends=('libgbm1-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libgbm-amdgpu-pro-dev_16.30.3-306809_amd64
@@ -635,7 +635,7 @@ package_libgbm-amdgpu-pro-dev () {
 
 package_libgbm1-amdgpu-pro () {
 	pkgdesc="generic buffer management API -- runtime"
-	depends=('libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4' 'libdrm2-amdgpu-pro=16.30.3.306809-4')
+	depends=('libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5' 'libdrm2-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libgbm1-amdgpu-pro_16.30.3-306809_amd64
@@ -654,7 +654,7 @@ package_libgbm1-amdgpu-pro () {
 
 package_lib32-libgbm1-amdgpu-pro () {
 	pkgdesc="generic buffer management API -- runtime"
-	depends=('lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4' 'lib32-libdrm2-amdgpu-pro=16.30.3.306809-4')
+	depends=('lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5' 'lib32-libdrm2-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libgbm1-amdgpu-pro_16.30.3-306809_i386
@@ -674,7 +674,7 @@ package_lib32-libgbm1-amdgpu-pro () {
 
 package_lib32-libgl1-amdgpu-pro-dev () {
 	pkgdesc="implementation of the OpenGL API -- GLX development files"
-	depends=('lib32-libgl1-amdgpu-pro-glx=16.30.3.306809-4')
+	depends=('lib32-libgl1-amdgpu-pro-glx=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libgl1-amdgpu-pro-dev_16.30.3-306809_i386
@@ -698,7 +698,7 @@ package_lib32-libgl1-amdgpu-pro-dev () {
 
 package_libgl1-amdgpu-pro-dev () {
 	pkgdesc="implementation of the OpenGL API -- GLX development files"
-	depends=('libgl1-amdgpu-pro-glx=16.30.3.306809-4')
+	depends=('libgl1-amdgpu-pro-glx=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libgl1-amdgpu-pro-dev_16.30.3-306809_amd64
@@ -760,7 +760,7 @@ package_libgl1-amdgpu-pro-dri () {
 
 package_lib32-libgl1-amdgpu-pro-glx () {
 	pkgdesc="implementation of the OpenGL API -- GLX runtime"
-	depends=('lib32-libdrm2-amdgpu-pro=16.30.3.306809-4' 'lib32-libx11>=1.4.99.1' 'lib32-libxcb>=1.8' 'lib32-libxcb' 'lib32-libxcb>=1.9.2' 'lib32-libxdamage>=1.1' 'lib32-libxext' 'lib32-libxfixes' 'lib32-libxshmfence' 'lib32-libxxf86vm')
+	depends=('lib32-libdrm2-amdgpu-pro=16.30.3.306809-5' 'lib32-libx11>=1.4.99.1' 'lib32-libxcb>=1.8' 'lib32-libxcb' 'lib32-libxcb>=1.9.2' 'lib32-libxdamage>=1.1' 'lib32-libxext' 'lib32-libxfixes' 'lib32-libxshmfence' 'lib32-libxxf86vm')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libgl1-amdgpu-pro-glx_16.30.3-306809_i386
@@ -784,7 +784,7 @@ package_lib32-libgl1-amdgpu-pro-glx () {
 
 package_libgl1-amdgpu-pro-glx () {
 	pkgdesc="implementation of the OpenGL API -- GLX runtime"
-	depends=('libdrm2-amdgpu-pro=16.30.3.306809-4' 'libx11>=1.4.99.1' 'libxcb>=1.8' 'libxcb' 'libxcb>=1.9.2' 'libxdamage>=1.1' 'libxext' 'libxfixes' 'libxshmfence' 'libxxf86vm')
+	depends=('libdrm2-amdgpu-pro=16.30.3.306809-5' 'libx11>=1.4.99.1' 'libxcb>=1.8' 'libxcb' 'libxcb>=1.9.2' 'libxdamage>=1.1' 'libxext' 'libxfixes' 'libxshmfence' 'libxxf86vm')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libgl1-amdgpu-pro-glx_16.30.3-306809_amd64
@@ -807,7 +807,7 @@ package_libgl1-amdgpu-pro-glx () {
 
 package_libgles2-amdgpu-pro () {
 	pkgdesc="implementation of the OpenGL|ES 2.x API -- runtime"
-	depends=('libegl1-amdgpu-pro=16.30.3.306809-4')
+	depends=('libegl1-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libgles2-amdgpu-pro_16.30.3-306809_amd64
@@ -826,7 +826,7 @@ package_libgles2-amdgpu-pro () {
 
 package_lib32-libgles2-amdgpu-pro () {
 	pkgdesc="implementation of the OpenGL|ES 2.x API -- runtime"
-	depends=('lib32-libegl1-amdgpu-pro=16.30.3.306809-4')
+	depends=('lib32-libegl1-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libgles2-amdgpu-pro_16.30.3-306809_i386
@@ -846,7 +846,7 @@ package_lib32-libgles2-amdgpu-pro () {
 
 package_lib32-libgles2-amdgpu-pro-dev () {
 	pkgdesc="implementation of the OpenGL|ES 2.x API -- development files"
-	depends=('lib32-libgles2-amdgpu-pro=16.30.3.306809-4')
+	depends=('lib32-libgles2-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libgles2-amdgpu-pro-dev_16.30.3-306809_i386
@@ -870,7 +870,7 @@ package_lib32-libgles2-amdgpu-pro-dev () {
 
 package_libgles2-amdgpu-pro-dev () {
 	pkgdesc="implementation of the OpenGL|ES 2.x API -- development files"
-	depends=('libgles2-amdgpu-pro=16.30.3.306809-4')
+	depends=('libgles2-amdgpu-pro=16.30.3.306809-5')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libgles2-amdgpu-pro-dev_16.30.3-306809_amd64
@@ -893,7 +893,7 @@ package_libgles2-amdgpu-pro-dev () {
 
 package_libvdpau-amdgpu-pro () {
 	pkgdesc="AMDGPU Pro VDPAU driver"
-	depends=('libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4' 'libdrm>=2.4.31' 'libdrm2-amdgpu-pro=16.30.3.306809-4' 'openssl>=1.0.0' 'libx11' 'libxcb>=1.8' 'libxcb')
+	depends=('libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5' 'libdrm>=2.4.31' 'libdrm2-amdgpu-pro=16.30.3.306809-5' 'openssl>=1.0.0' 'libx11' 'libxcb>=1.8' 'libxcb')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libvdpau-amdgpu-pro_16.30.3-306809_amd64
@@ -912,7 +912,7 @@ package_libvdpau-amdgpu-pro () {
 
 package_lib32-libvdpau-amdgpu-pro () {
 	pkgdesc="AMDGPU Pro VDPAU driver"
-	depends=('lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4' 'lib32-libdrm>=2.4.31' 'lib32-libdrm2-amdgpu-pro=16.30.3.306809-4' 'lib32-openssl>=1.0.0' 'lib32-libx11' 'lib32-libxcb>=1.8' 'lib32-libxcb' 'lib32-zlib>=1.2.0')
+	depends=('lib32-libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5' 'lib32-libdrm>=2.4.31' 'lib32-libdrm2-amdgpu-pro=16.30.3.306809-5' 'lib32-openssl>=1.0.0' 'lib32-libx11' 'lib32-libxcb>=1.8' 'lib32-libxcb' 'lib32-zlib>=1.2.0')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/libvdpau-amdgpu-pro_16.30.3-306809_i386
@@ -932,7 +932,7 @@ package_lib32-libvdpau-amdgpu-pro () {
 
 package_xserver-xorg-video-amdgpu-pro () {
 	pkgdesc="X.Org X server -- AMD/ATI Amdgpu-Pro display driver"
-	depends=('libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-4' 'libdrm2-amdgpu-pro=16.30.3.306809-4' 'libepoxy>=1.0' 'libgbm1-amdgpu-pro=16.30.3.306809-4' 'libgl1-amdgpu-pro-glx=16.30.3.306809-4' 'libsystemd>=183' 'libx11' 'libxcb' 'libxdamage>=1.1' 'libxext' 'libxfixes' 'libxxf86vm' 'xorg-server')
+	depends=('libdrm-amdgpu-pro-amdgpu1=16.30.3.306809-5' 'libdrm2-amdgpu-pro=16.30.3.306809-5' 'libepoxy>=1.0' 'libgbm1-amdgpu-pro=16.30.3.306809-5' 'libgl1-amdgpu-pro-glx=16.30.3.306809-5' 'libsystemd>=183' 'libx11' 'libxcb' 'libxdamage>=1.1' 'libxext' 'libxfixes' 'libxxf86vm' 'xorg-server')
 	arch=('x86_64')
 
 	rm -Rf "${srcdir}"/xserver-xorg-video-amdgpu-pro_16.30.3-306809_amd64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -30,6 +30,12 @@ package_amdgpu-pro () {
 	cd "${srcdir}"/amdgpu-pro_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -43,6 +49,12 @@ package_amdgpu-pro-clinfo () {
 	cd "${srcdir}"/amdgpu-pro-clinfo_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-clinfo_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -56,6 +68,12 @@ package_amdgpu-pro-computing () {
 	cd "${srcdir}"/amdgpu-pro-computing_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-computing_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -70,7 +88,15 @@ package_amdgpu-pro-core () {
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-core_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
 
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
+
 	mv ${pkgdir}/lib ${pkgdir}/usr/
+	sed -i 's/\/usr\/lib\/x86_64-linux-gnu\//\/usr\/lib\//' ${pkgdir}/usr/lib/amdgpu-pro/ld.conf
+	sed -i 's/\/usr\/lib\/i386-linux-gnu\//\/usr\/lib32\//' ${pkgdir}/usr/lib/amdgpu-pro/ld.conf
 	mkdir -p ${pkgdir}/etc/ld.so.conf.d/
 	ln -s /usr/lib/amdgpu-pro/ld.conf ${pkgdir}/etc/ld.so.conf.d/10-amdgpu-pro.conf
 	mkdir -p ${pkgdir}/etc/modprobe.d/
@@ -90,6 +116,12 @@ package_amdgpu-pro-dkms () {
 	cd "${srcdir}"/amdgpu-pro-dkms_16.30.3-306809_all
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-dkms_16.30.3-306809_all.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -103,6 +135,12 @@ package_amdgpu-pro-firmware () {
 	cd "${srcdir}"/amdgpu-pro-firmware_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-firmware_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 
 	mv ${pkgdir}/lib ${pkgdir}/usr/
 
@@ -119,6 +157,12 @@ package_amdgpu-pro-graphics () {
 	cd "${srcdir}"/amdgpu-pro-graphics_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-graphics_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 
 	provides=('libgl')
 	conflicts=('libgl')
@@ -137,6 +181,12 @@ package_lib32-amdgpu-pro-lib32 () {
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-lib32_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
 
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
+
 	provides=('lib32-libgl')
 	conflicts=('lib32-libgl')
 
@@ -154,6 +204,16 @@ package_lib32-amdgpu-pro-libopencl-dev () {
 	cd "${srcdir}"/amdgpu-pro-libopencl-dev_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-libopencl-dev_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
+
+	provides=(lib32-libcl)
+	conflicts=(lib32-libcl)
+
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -168,6 +228,16 @@ package_amdgpu-pro-libopencl-dev () {
 	cd "${srcdir}"/amdgpu-pro-libopencl-dev_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-libopencl-dev_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
+
+	provides=(libcl)
+	conflicts=(libcl)
+
 }
 
 
@@ -181,6 +251,12 @@ package_lib32-amdgpu-pro-libopencl1 () {
 	cd "${srcdir}"/amdgpu-pro-libopencl1_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-libopencl1_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -195,6 +271,12 @@ package_amdgpu-pro-libopencl1 () {
 	cd "${srcdir}"/amdgpu-pro-libopencl1_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-libopencl1_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -208,6 +290,12 @@ package_lib32-amdgpu-pro-opencl-icd () {
 	cd "${srcdir}"/amdgpu-pro-opencl-icd_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-opencl-icd_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -222,6 +310,12 @@ package_amdgpu-pro-opencl-icd () {
 	cd "${srcdir}"/amdgpu-pro-opencl-icd_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-opencl-icd_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -235,6 +329,15 @@ package_amdgpu-pro-vulkan-driver () {
 	cd "${srcdir}"/amdgpu-pro-vulkan-driver_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-vulkan-driver_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
+
+	sed -i 's/\/usr\/lib\/x86_64-linux-gnu\//\/usr\/lib\//' ${pkgdir}/etc/vulkan/icd.d/amd_icd64.json
+
 }
 
 
@@ -248,6 +351,15 @@ package_lib32-amdgpu-pro-vulkan-driver () {
 	cd "${srcdir}"/amdgpu-pro-vulkan-driver_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./amdgpu-pro-vulkan-driver_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
+
+	sed -i 's/\/usr\/lib\/i386-linux-gnu\//\/usr\/lib32\//' ${pkgdir}/etc/vulkan/icd.d/amd_icd32.json
+
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -262,6 +374,12 @@ package_libdrm-amdgpu-pro-amdgpu1 () {
 	cd "${srcdir}"/libdrm-amdgpu-pro-amdgpu1_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libdrm-amdgpu-pro-amdgpu1_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -275,6 +393,12 @@ package_lib32-libdrm-amdgpu-pro-amdgpu1 () {
 	cd "${srcdir}"/libdrm-amdgpu-pro-amdgpu1_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./libdrm-amdgpu-pro-amdgpu1_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -289,6 +413,12 @@ package_libdrm-amdgpu-pro-dev () {
 	cd "${srcdir}"/libdrm-amdgpu-pro-dev_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libdrm-amdgpu-pro-dev_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -302,6 +432,12 @@ package_lib32-libdrm-amdgpu-pro-dev () {
 	cd "${srcdir}"/libdrm-amdgpu-pro-dev_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./libdrm-amdgpu-pro-dev_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -316,6 +452,12 @@ package_libdrm-amdgpu-pro-tools () {
 	cd "${srcdir}"/libdrm-amdgpu-pro-tools_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libdrm-amdgpu-pro-tools_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -329,6 +471,12 @@ package_libdrm2-amdgpu-pro () {
 	cd "${srcdir}"/libdrm2-amdgpu-pro_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libdrm2-amdgpu-pro_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -342,6 +490,12 @@ package_lib32-libdrm2-amdgpu-pro () {
 	cd "${srcdir}"/libdrm2-amdgpu-pro_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./libdrm2-amdgpu-pro_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -356,6 +510,16 @@ package_libegl1-amdgpu-pro () {
 	cd "${srcdir}"/libegl1-amdgpu-pro_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libegl1-amdgpu-pro_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
+
+	mv ${pkgdir}/usr/lib/amdgpu-pro/libEGL* ${pkgdir}/usr/lib
+	rm -r ${pkgdir}/usr/lib/amdgpu-pro
+
 }
 
 
@@ -369,6 +533,16 @@ package_lib32-libegl1-amdgpu-pro () {
 	cd "${srcdir}"/libegl1-amdgpu-pro_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./libegl1-amdgpu-pro_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
+
+	mv ${pkgdir}/usr/lib32/amdgpu-pro/libEGL* ${pkgdir}/usr/lib32
+	rm -r ${pkgdir}/usr/lib32/amdgpu-pro
+
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -383,6 +557,16 @@ package_libegl1-amdgpu-pro-dev () {
 	cd "${srcdir}"/libegl1-amdgpu-pro-dev_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libegl1-amdgpu-pro-dev_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
+
+	mv ${pkgdir}/usr/lib/amdgpu-pro/libEGL* ${pkgdir}/usr/lib
+	rm -r ${pkgdir}/usr/lib/amdgpu-pro
+
 }
 
 
@@ -396,6 +580,16 @@ package_lib32-libegl1-amdgpu-pro-dev () {
 	cd "${srcdir}"/libegl1-amdgpu-pro-dev_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./libegl1-amdgpu-pro-dev_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
+
+	mv ${pkgdir}/usr/lib32/amdgpu-pro/libEGL* ${pkgdir}/usr/lib32
+	rm -r ${pkgdir}/usr/lib32/amdgpu-pro
+
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -410,6 +604,12 @@ package_lib32-libgbm-amdgpu-pro-dev () {
 	cd "${srcdir}"/libgbm-amdgpu-pro-dev_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgbm-amdgpu-pro-dev_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -424,6 +624,12 @@ package_libgbm-amdgpu-pro-dev () {
 	cd "${srcdir}"/libgbm-amdgpu-pro-dev_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgbm-amdgpu-pro-dev_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -437,6 +643,12 @@ package_libgbm1-amdgpu-pro () {
 	cd "${srcdir}"/libgbm1-amdgpu-pro_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgbm1-amdgpu-pro_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -450,6 +662,12 @@ package_lib32-libgbm1-amdgpu-pro () {
 	cd "${srcdir}"/libgbm1-amdgpu-pro_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgbm1-amdgpu-pro_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -464,6 +682,16 @@ package_lib32-libgl1-amdgpu-pro-dev () {
 	cd "${srcdir}"/libgl1-amdgpu-pro-dev_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgl1-amdgpu-pro-dev_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
+
+	mv ${pkgdir}/usr/lib32/amdgpu-pro/libGL* ${pkgdir}/usr/lib32
+	rm -r ${pkgdir}/usr/lib32/amdgpu-pro
+
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -478,6 +706,16 @@ package_libgl1-amdgpu-pro-dev () {
 	cd "${srcdir}"/libgl1-amdgpu-pro-dev_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgl1-amdgpu-pro-dev_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
+
+	mv ${pkgdir}/usr/lib/amdgpu-pro/libGL* ${pkgdir}/usr/lib
+	rm -r ${pkgdir}/usr/lib/amdgpu-pro
+
 }
 
 
@@ -491,6 +729,12 @@ package_lib32-libgl1-amdgpu-pro-dri () {
 	cd "${srcdir}"/libgl1-amdgpu-pro-dri_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgl1-amdgpu-pro-dri_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -505,6 +749,12 @@ package_libgl1-amdgpu-pro-dri () {
 	cd "${srcdir}"/libgl1-amdgpu-pro-dri_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgl1-amdgpu-pro-dri_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -518,6 +768,16 @@ package_lib32-libgl1-amdgpu-pro-glx () {
 	cd "${srcdir}"/libgl1-amdgpu-pro-glx_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgl1-amdgpu-pro-glx_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
+
+	mv ${pkgdir}/usr/lib32/amdgpu-pro/libGL* ${pkgdir}/usr/lib32
+	rm -r ${pkgdir}/usr/lib32/amdgpu-pro
+
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -532,6 +792,16 @@ package_libgl1-amdgpu-pro-glx () {
 	cd "${srcdir}"/libgl1-amdgpu-pro-glx_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgl1-amdgpu-pro-glx_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
+
+	mv ${pkgdir}/usr/lib/amdgpu-pro/libGL* ${pkgdir}/usr/lib
+	rm -r ${pkgdir}/usr/lib/amdgpu-pro
+
 }
 
 
@@ -545,6 +815,12 @@ package_libgles2-amdgpu-pro () {
 	cd "${srcdir}"/libgles2-amdgpu-pro_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgles2-amdgpu-pro_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -558,6 +834,12 @@ package_lib32-libgles2-amdgpu-pro () {
 	cd "${srcdir}"/libgles2-amdgpu-pro_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgles2-amdgpu-pro_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -572,6 +854,16 @@ package_lib32-libgles2-amdgpu-pro-dev () {
 	cd "${srcdir}"/libgles2-amdgpu-pro-dev_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgles2-amdgpu-pro-dev_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
+
+	mv ${pkgdir}/usr/lib32/amdgpu-pro/libGLES* ${pkgdir}/usr/lib32
+	rm -r ${pkgdir}/usr/lib32/amdgpu-pro
+
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -586,6 +878,16 @@ package_libgles2-amdgpu-pro-dev () {
 	cd "${srcdir}"/libgles2-amdgpu-pro-dev_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libgles2-amdgpu-pro-dev_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
+
+	mv ${pkgdir}/usr/lib/amdgpu-pro/libGLES* ${pkgdir}/usr/lib
+	rm -r ${pkgdir}/usr/lib/amdgpu-pro
+
 }
 
 
@@ -599,6 +901,12 @@ package_libvdpau-amdgpu-pro () {
 	cd "${srcdir}"/libvdpau-amdgpu-pro_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./libvdpau-amdgpu-pro_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
 }
 
 
@@ -612,6 +920,12 @@ package_lib32-libvdpau-amdgpu-pro () {
 	cd "${srcdir}"/libvdpau-amdgpu-pro_16.30.3-306809_i386
 	ar x "${srcdir}"/amdgpu-pro-driver/./libvdpau-amdgpu-pro_16.30.3-306809_i386.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
+
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
 	rm -Rf ${pkgdir}/usr/share/doc ${pkgdir}/usr/include
 }
 
@@ -626,6 +940,18 @@ package_xserver-xorg-video-amdgpu-pro () {
 	cd "${srcdir}"/xserver-xorg-video-amdgpu-pro_16.30.3-306809_amd64
 	ar x "${srcdir}"/amdgpu-pro-driver/./xserver-xorg-video-amdgpu-pro_16.30.3-306809_amd64.deb
 	tar -C "${pkgdir}" -xf data.tar.xz
-	ln -sfn 1.18 ${pkgdir}/usr/lib/x86_64-linux-gnu/amdgpu-pro/xorg
+
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
+
+	mkdir -p ${pkgdir}/usr/lib/x86_64-linux-gnu
+	# This is needed because libglx.so has a hardcoded DRI_DRIVER_PATH
+	ln -s /usr/lib/dri ${pkgdir}/usr/lib/x86_64-linux-gnu/dri
+	mv ${pkgdir}/usr/lib/amdgpu-pro/1.18/ ${pkgdir}/usr/lib/xorg
+	rm -r ${pkgdir}/usr/lib/amdgpu-pro
+
 }
 

--- a/gen-PKGBUILD.py
+++ b/gen-PKGBUILD.py
@@ -63,6 +63,22 @@ package_{NAME} () {{
 	tar -C "${{pkgdir}}" -xf data.tar.xz
 """
 
+package_header_i386 = """
+	if [ -d "${pkgdir}/usr/lib/i386-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib32
+		mv "${pkgdir}"/usr/lib/i386-linux-gnu/* "${pkgdir}"/usr/lib32
+		rmdir "${pkgdir}"/usr/lib/i386-linux-gnu
+	fi
+"""
+
+package_header_x86_64 = """
+	if [ -d "${pkgdir}/usr/lib/x86_64-linux-gnu" ]; then
+		mkdir -p "${pkgdir}"/usr/lib
+		mv "${pkgdir}"/usr/lib/x86_64-linux-gnu/* "${pkgdir}"/usr/lib
+		rmdir "${pkgdir}"/usr/lib/x86_64-linux-gnu
+	fi
+"""
+
 package_footer = """}
 """
 
@@ -71,12 +87,14 @@ special_ops = {
 	provides=('libgl')
 	conflicts=('libgl')
 """,
-	"amdgpu-pro-lib32": """
+	"lib32-amdgpu-pro-lib32": """
 	provides=('lib32-libgl')
 	conflicts=('lib32-libgl')
 """,
 	"amdgpu-pro-core": """
 	mv ${pkgdir}/lib ${pkgdir}/usr/
+	sed -i 's/\/usr\/lib\/x86_64-linux-gnu\//\/usr\/lib\//' ${pkgdir}/usr/lib/amdgpu-pro/ld.conf
+	sed -i 's/\/usr\/lib\/i386-linux-gnu\//\/usr\/lib32\//' ${pkgdir}/usr/lib/amdgpu-pro/ld.conf
 	mkdir -p ${pkgdir}/etc/ld.so.conf.d/
 	ln -s /usr/lib/amdgpu-pro/ld.conf ${pkgdir}/etc/ld.so.conf.d/10-amdgpu-pro.conf
 	mkdir -p ${pkgdir}/etc/modprobe.d/
@@ -86,7 +104,71 @@ special_ops = {
 	"amdgpu-pro-firmware": """
 	mv ${pkgdir}/lib ${pkgdir}/usr/
 """,
-	"xserver-xorg-video-amdgpu-pro": "\tln -sfn 1.18 ${pkgdir}/usr/lib/x86_64-linux-gnu/amdgpu-pro/xorg",
+
+	"xserver-xorg-video-amdgpu-pro": """
+	mkdir -p ${pkgdir}/usr/lib/x86_64-linux-gnu
+	# This is needed because libglx.so has a hardcoded DRI_DRIVER_PATH
+	ln -s /usr/lib/dri ${pkgdir}/usr/lib/x86_64-linux-gnu/dri
+	mv ${pkgdir}/usr/lib/amdgpu-pro/1.18/ ${pkgdir}/usr/lib/xorg
+	rm -r ${pkgdir}/usr/lib/amdgpu-pro
+""",
+	"libegl1-amdgpu-pro-dev": """
+	mv ${pkgdir}/usr/lib/amdgpu-pro/libEGL* ${pkgdir}/usr/lib
+	rm -r ${pkgdir}/usr/lib/amdgpu-pro
+""",
+	"libegl1-amdgpu-pro": """
+	mv ${pkgdir}/usr/lib/amdgpu-pro/libEGL* ${pkgdir}/usr/lib
+	rm -r ${pkgdir}/usr/lib/amdgpu-pro
+""",
+	"libgl1-amdgpu-pro-dev": """
+	mv ${pkgdir}/usr/lib/amdgpu-pro/libGL* ${pkgdir}/usr/lib
+	rm -r ${pkgdir}/usr/lib/amdgpu-pro
+""",
+	"libgl1-amdgpu-pro-glx": """
+	mv ${pkgdir}/usr/lib/amdgpu-pro/libGL* ${pkgdir}/usr/lib
+	rm -r ${pkgdir}/usr/lib/amdgpu-pro
+""",
+	"libgles2-amdgpu-pro-dev": """
+	mv ${pkgdir}/usr/lib/amdgpu-pro/libGLES* ${pkgdir}/usr/lib
+	rm -r ${pkgdir}/usr/lib/amdgpu-pro
+""",
+
+	"lib32-libegl1-amdgpu-pro-dev": """
+	mv ${pkgdir}/usr/lib32/amdgpu-pro/libEGL* ${pkgdir}/usr/lib32
+	rm -r ${pkgdir}/usr/lib32/amdgpu-pro
+""",
+	"lib32-libegl1-amdgpu-pro": """
+	mv ${pkgdir}/usr/lib32/amdgpu-pro/libEGL* ${pkgdir}/usr/lib32
+	rm -r ${pkgdir}/usr/lib32/amdgpu-pro
+""",
+	"lib32-libgl1-amdgpu-pro-dev": """
+	mv ${pkgdir}/usr/lib32/amdgpu-pro/libGL* ${pkgdir}/usr/lib32
+	rm -r ${pkgdir}/usr/lib32/amdgpu-pro
+""",
+	"lib32-libgl1-amdgpu-pro-glx": """
+	mv ${pkgdir}/usr/lib32/amdgpu-pro/libGL* ${pkgdir}/usr/lib32
+	rm -r ${pkgdir}/usr/lib32/amdgpu-pro
+""",
+	"lib32-libgles2-amdgpu-pro-dev": """
+	mv ${pkgdir}/usr/lib32/amdgpu-pro/libGLES* ${pkgdir}/usr/lib32
+	rm -r ${pkgdir}/usr/lib32/amdgpu-pro
+""",
+
+	"amdgpu-pro-vulkan-driver": """
+	sed -i 's/\/usr\/lib\/x86_64-linux-gnu\//\/usr\/lib\//' ${pkgdir}/etc/vulkan/icd.d/amd_icd64.json
+""",
+	"lib32-amdgpu-pro-vulkan-driver": """
+	sed -i 's/\/usr\/lib\/i386-linux-gnu\//\/usr\/lib32\//' ${pkgdir}/etc/vulkan/icd.d/amd_icd32.json
+""",
+
+	"amdgpu-pro-libopencl-dev": """
+	provides=(libcl)
+	conflicts=(libcl)
+""",
+	"lib32-amdgpu-pro-libopencl-dev": """
+	provides=(lib32-libcl)
+	conflicts=(lib32-libcl)
+""",
 }
 
 replace_deps = {
@@ -118,6 +200,10 @@ replace_deps = {
 	"zlib1g": "zlib",
 }
 
+replace_version = {
+	"linux-firmware": "",
+}
+
 dependency = re.compile(r"([^ ]+)(?: \((.+)\))?")
 
 arch_map = {
@@ -131,6 +217,9 @@ optional_packages = frozenset([
 	"amdgpu-pro-dkms"
 ])
 
+disabled_packages = frozenset([
+])
+
 deb_archs={}
 
 def quote(string):
@@ -142,8 +231,8 @@ def convertName(name, info):
 	return name
 
 def convertVersionSpecifier(name, spec, names):
-	if name == "linux-firmware":
-		return ""
+	if name in replace_version:
+		return replace_version[name]
 	if name in names:
 		return "=" + pkgver + "-" + str(pkgrel)
 	if not spec:
@@ -178,7 +267,7 @@ def convertPackage(info, names):
 			deps2.append(dep)
 	deps = "(" + " ".join(deps2) + ")"
 
-	special_op = special_ops[info["Package"]] if info["Package"] in special_ops else ""
+	special_op = special_ops[name] if name in special_ops else ""
 
 	desc = info["Description"].split("\n")
 	if len(desc) > 2:
@@ -187,6 +276,12 @@ def convertPackage(info, names):
 		desc = " ".join(x.strip() for x in desc)
 
 	ret = package_header_tpl.format(DEPENDS=deps, NAME=name, ARCH=arch, DESC=quote(desc), **info)
+
+	if info["Architecture"] == "i386":
+		ret += package_header_i386
+	else:
+		ret += package_header_x86_64
+
 	if special_op:
 		ret += special_op + "\n"
 	if info["Architecture"] == "i386":
@@ -208,7 +303,9 @@ def writePackages(f):
 
 		name = "lib32-" + info["Package"] if info["Architecture"] == "i386" else info["Package"]
 
-		if info["Package"] in optional_packages:
+		if info["Package"] in disabled_packages:
+			continue
+		elif info["Package"] in optional_packages:
 			optional_names.append(name)
 		else:
 			package_names.append(name)

--- a/gen-PKGBUILD.py
+++ b/gen-PKGBUILD.py
@@ -8,7 +8,7 @@ import hashlib
 
 pkgver_base = "16.30.3"
 pkgver_build = "306809"
-pkgrel = 4
+pkgrel = 5
 
 pkgver = "{0}.{1}".format(pkgver_base, pkgver_build)
 url_ref="http://support.amd.com/en-us/kb-articles/Pages/AMDGPU-PRO-Beta-Driver-for-Vulkan-Release-Notes.aspx"


### PR DESCRIPTION
This should fix #7 and #9.

Almost completely got rid of the debian lib paths.  One symlink is still needed beacuse of the hardcoded DRI_DRIVER_PATH in libglx.so.

tested: vulkan, gl, vdpau 64-bit, gl 32-bit
not tested: vulkan, vdpau 32-bit, opencl